### PR TITLE
Add typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Closes #19

## Summary
- Adds `"typecheck": "tsc --noEmit"` to `package.json`, giving a fast standalone TypeScript check separate from the full `next build`.

## Exit Criteria
- [x] `package.json` has a `"typecheck": "tsc --noEmit"` script
- [x] Running `npm run typecheck` from a clean checkout exits 0 with no errors on the current codebase
- [x] Running `npm run typecheck` after introducing a deliberate type error (assigned a string to a number-typed const in `lib/utils.ts`, reverted after) exits non-zero and reports the error clearly

## Verification
- `npm run typecheck` - clean, exit 0
- `npm run build` - passes
- `npm run lint` - 4 pre-existing errors in app/dashboard/food/** (unused vars), unrelated to this change and present on main before this branch; out of scope for this issue

## Docs
Docs reviewed, no update needed - this is a one-line package.json script addition with no architectural impact.
