### PR TITLE
Add Playwright for e2e regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1534,6 +1535,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8008,6 +8025,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3100;
+const baseURL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `npx next dev -p ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/tests/e2e/unauthenticated-access.spec.ts
+++ b/tests/e2e/unauthenticated-access.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+// These flows don't require signing in, so they exercise real
+// server-side auth-gating (see lib/supabase/proxy.ts) without needing
+// Google OAuth, which can't be driven directly in this test environment.
+
+test("home page prompts an unauthenticated visitor to sign in", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByText("Please sign-in to see your dashboard"),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Dashboard" })).toHaveCount(0);
+});
+
+test("visiting /dashboard while unauthenticated redirects home", async ({
+  page,
+}) => {
+  await page.goto("/dashboard");
+
+  await expect(page).toHaveURL("/");
+  await expect(
+    page.getByText("Please sign-in to see your dashboard"),
+  ).toBeVisible();
+});


### PR DESCRIPTION
Closes #21

## Summary
- Installs `@playwright/test` as a dev dependency and adds `playwright.config.ts`. It launches `next dev` on a dedicated port (3100) via the `webServer` option and runs against Chromium.
- Adds `"test:e2e": "playwright test"` to `package.json`.
- Adds `tests/e2e/unauthenticated-access.spec.ts` with two real tests exercising the app's server-side auth gating (`lib/supabase/proxy.ts`):
  1. The home page shows the "Please sign-in to see your dashboard" prompt (and no Dashboard link) when unauthenticated.
  2. Visiting `/dashboard` while unauthenticated redirects to `/` (the actual proxy redirect behavior, not just a page-loads check).
- Adds `/test-results/`, `/playwright-report/`, `/playwright/.cache/` to `.gitignore`.

## Authentication approach
This first test suite is scoped to **unauthenticated flows only** — no login is performed. These flows are login-independent by design (home page + redirect-to-home behavior), so they don't need Google OAuth, which can't be driven directly in this test/CI environment. Testing authenticated flows (e.g. access-level gating on `/dashboard` for a given user tier) is out of reach until there's a way to seed a session — noting this so a future issue can pick it up (e.g. a test-only Supabase session/cookie seeding helper).

## Exit Criteria
- [x] Playwright is installed as a dev dependency and configured (`playwright.config.ts`)
- [x] `package.json` has a `"test:e2e": "playwright test"` script
- [x] At least one real test file exists under `tests/e2e/` exercising a genuine user-facing flow (auth-gating redirect + sign-in prompt, not just "page loads and has a title")
- [x] Running `npm run test:e2e` from a clean checkout passes (2/2 passing)
- [x] The PR documents how the test authenticates (it doesn't — see "Authentication approach" above — and notes what's out of reach without real OAuth)

## Verification
- `npm run test:e2e` — 2/2 passing, twice in a row
- Verified a deliberately broken assertion (`toHaveURL` pointed at a bogus path) fails clearly with an expected-vs-received diff; reverted before commit
- `npm run typecheck` — clean
- `npm run test` (Vitest) — still 24/24 passing, unaffected
- `npm run build` — passes
- `npm run lint` — 4 pre-existing errors in `app/dashboard/food/**` (unused vars), unrelated to this change and present on `main` before this branch; out of scope for this issue

## Docs
Docs reviewed, no update needed. Note: `docs/architecture/*.md` don't currently exist on `main` (tracked separately in [#25](https://github.com/Temel00/emelbros-webapp/issues/25)).
