### PR TITLE
Add agent-task GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.md
+++ b/.github/ISSUE_TEMPLATE/agent-task.md
@@ -1,0 +1,20 @@
+---
+name: Agent Task
+about: A task for the agent loop to pick up (see AGENTS.md)
+title: ""
+labels: ""
+---
+
+## Description
+What needs to change and why.
+
+## Context
+Optional: relevant docs/architecture/*.md links, affected routes/files if known.
+
+## Exit Criteria
+<!-- Each criterion must be concrete and checkable (e.g. "npm run test:e2e passes"), not subjective (e.g. "code is clean"). -->
+- [ ] Specific, checkable criterion 1
+- [ ] Specific, checkable criterion 2
+
+## Blocked by
+(optional: #issue-number references)


### PR DESCRIPTION
Closes #22

## Summary
- Adds `.github/ISSUE_TEMPLATE/agent-task.md` with front-matter (`name: Agent Task`, `about`) and the four sections specified in AGENTS.md's "Issue template" section: Description, Context, Exit Criteria, Blocked by.
- The Exit Criteria section includes an inline HTML comment reminding the author that criteria must be concrete/checkable, not subjective.

## Exit Criteria
- [x] `.github/ISSUE_TEMPLATE/agent-task.md` exists with front-matter (`name: Agent Task`, appropriate `about`/`title`) and the four sections from AGENTS.md: Description, Context, Exit Criteria, Blocked by
- [x] Creating a new issue in the GitHub UI (`Repo → Issues → New issue`) offers "Agent Task" as a template option and pre-fills the four sections (standard GitHub issue-template mechanism — file lives at the required path with valid front-matter)
- [x] The template's Exit Criteria section includes a short inline comment/example reminding the author that criteria must be concrete/checkable, not subjective

## Verification
- `npm run typecheck` — clean
- `npm run lint` — 4 pre-existing errors in `app/dashboard/food/**` (unused vars), unrelated to this change and present on `main` before this branch
- `npm run build` — passes
- Docs/template-only change — no code touched, so Vitest/Playwright suites are unaffected

## Docs
No doc-sync needed — this only adds a GitHub issue template, doesn't change app behavior or architecture. `docs/architecture/*.md` still don't exist on `main` (tracked in #25).
