### PR TITLE
Add CI workflow (build/lint/typecheck/vitest/playwright)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run test
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e

--- a/app/dashboard/food/(tabbed)/inventory/widgets.tsx
+++ b/app/dashboard/food/(tabbed)/inventory/widgets.tsx
@@ -6,7 +6,6 @@ import {
   useEffect,
   useRef,
   useCallback,
-  useTransition,
 } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import {

--- a/app/dashboard/food/(tabbed)/recipes/page.tsx
+++ b/app/dashboard/food/(tabbed)/recipes/page.tsx
@@ -60,8 +60,6 @@ async function RecipesListWithFilters({
         tagIds={tagIds}
         toolIds={toolIds}
         timeRange={timeRange}
-        allTags={allTags}
-        allTools={allTools}
       />
     </>
   );

--- a/app/dashboard/food/(tabbed)/recipes/widgets.tsx
+++ b/app/dashboard/food/(tabbed)/recipes/widgets.tsx
@@ -2005,8 +2005,6 @@ export function InfiniteRecipesList({
   tagIds,
   toolIds,
   timeRange,
-  allTags,
-  allTools,
 }: {
   initialRecipes: RecipeWithTags[];
   initialHasMore: boolean;
@@ -2014,8 +2012,6 @@ export function InfiniteRecipesList({
   tagIds: string[];
   toolIds: string[];
   timeRange: number | null;
-  allTags: Tag[];
-  allTools: { id: string; name: string }[];
 }) {
   const [items, setItems] = useState<RecipeWithTags[]>(initialRecipes);
   const [hasMore, setHasMore] = useState(initialHasMore);

--- a/app/dashboard/food/household/widgets.tsx
+++ b/app/dashboard/food/household/widgets.tsx
@@ -34,7 +34,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
-import { Loader, Pencil, Plus, Trash2, LogOut, UserPlus, X } from "lucide-react";
+import { Loader, Pencil, Trash2, LogOut, UserPlus, X } from "lucide-react";
 
 const initialState: ActionState = { ok: true };
 


### PR DESCRIPTION
Closes #23

## Summary
- Adds `.github/workflows/ci.yml`, triggered on `pull_request` targeting `main`, with separate jobs for `build`, `lint`, `typecheck`, `test` (Vitest), and `test-e2e` (Playwright, installs Chromium via `npx playwright install --with-deps chromium` first).
- Also removes 4 genuinely-unused imports/props (`useTransition` in inventory widgets, `allTags`/`allTools` props threaded into `InfiniteRecipesList` but never read, `Plus` icon import in household widgets) — these were pre-existing `eslint` `no-unused-vars` failures on `main`. Without fixing them, the new `lint` job would be red immediately on merge, which would fail this issue's own "opening a PR with no code changes shows all checks green" exit criterion. All four were confirmed unused (not referenced anywhere in their scope) before removal.

## Required follow-up action (not something I can do myself)
The `build` and `test-e2e` jobs need `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` as **repository secrets** — confirmed locally that `next build` succeeds without them, but Playwright's e2e suite does not (the auth-gating redirect and sign-in-prompt text depend on a real Supabase client being constructible). I did not add these myself since modifying repo secrets is outside what I should do unilaterally; `gh secret list` currently shows none configured. **Until these two secrets are added in repo settings, the `build` and `test-e2e` jobs will fail on this and future PRs** — please add them (values are the same as this project's `.env.local`, and they're the public/anon Supabase keys already exposed client-side, not sensitive).

## Exit Criteria
- [x] `.github/workflows/ci.yml` exists, triggered on `pull_request` targeting `main`
- [x] The workflow runs `npm run build`, `npm run lint`, `npm run typecheck`, `npm run test`, and `npm run test:e2e` as separate jobs
- [ ] Opening a PR with no code changes shows all CI checks passing (green) — **blocked on the repo secrets above being added first**; once they're set, re-running this PR's checks should go green (verified locally: build/lint/typecheck/test/test:e2e all pass with the same env vars)
- [ ] Opening a PR with a deliberately broken step shows that check failing while others pass — not yet verified live in the Actions UI (same secrets blocker); the per-job separation guarantees only the broken job goes red while independent jobs still run, since GitHub Actions doesn't cancel sibling jobs on one job's failure by default

## Verification (local)
- `npm run build` — passes without any Supabase env vars set
- `npm run lint` — clean after removing the 4 unused imports/props above
- `npm run typecheck` — clean
- `npm run test` — 24/24 passing
- `npm run test:e2e` — 2/2 passing, but only with `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` set (fails otherwise) — this is why those two are wired into the `build` and `test-e2e` jobs' `env:`

## Docs
No `docs/architecture/*.md` update needed — AGENTS.md's existing "CI" section already describes this workflow generically and doesn't need edits. `docs/architecture/*.md` still don't exist on `main` (tracked in #25).
