### PR TITLE
Add review-standards custom skill

### DIFF
--- a/.claude/skills/review-standards/SKILL.md
+++ b/.claude/skills/review-standards/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: review-standards
+description: Review code against project coding standards defined in CLAUDE.md. Checks color usage, component patterns, responsive design, form patterns, imports, types, and overall style compliance.
+argument-hint: "[file-path or pattern]"
+allowed-tools: Read, Grep, Glob
+---
+
+# Code Standards Review
+
+Perform a comprehensive review of code against the project's CLAUDE.md coding standards.
+
+## Review Process
+
+When invoked with $ARGUMENTS:
+
+1. **Identify Files to Review**
+   - If no argument: Review recently modified files from git status
+   - If file path: Review that specific file
+   - If pattern (*.tsx): Use Glob to find matching files
+   - Focus on .tsx, .ts, and .css files
+
+2. **Read Each File**
+   - Use Read tool to examine file contents
+   - Note line numbers for any violations found
+
+3. **Check Against Standards** (in order of importance)
+
+## Standards Checklist
+
+### 🎨 CRITICAL: Color System & Theme Usage
+
+**Rule**: Never use hardcoded color classes. Always use semantic theme colors.
+
+Check for violations:
+- ❌ BAD: `text-red-600`, `bg-blue-500`, `text-green-600`, `border-gray-300`
+- ✅ GOOD: `text-destructive`, `bg-primary`, `text-tertiary`, `border-input`
+
+**Semantic color mappings** (from CLAUDE.md):
+- Errors/Destructive → `text-destructive`, `bg-destructive`, `bg-destructive/10`
+- Success/Positive → `text-tertiary`, `bg-tertiary`
+- Warnings/Alerts → `text-secondary`, `bg-secondary`, `bg-secondary/20`
+- Primary Actions → `bg-primary`, `text-primary`, `text-primary-foreground`
+- Accent → `bg-accent`, `bg-accent/10`, `bg-accent/20`
+- Muted/Secondary → `text-muted-foreground`
+
+**Search patterns** to flag:
+```regex
+text-(red|blue|green|yellow|purple|pink|gray|slate|zinc)-(\\d{3})
+bg-(red|blue|green|yellow|purple|pink|gray|slate|zinc)-(\\d{3})
+border-(red|blue|green|yellow|purple|pink|gray|slate|zinc)-(\\d{3})
+```
+
+### 🧩 Component Usage
+
+**Rule**: Always use shadcn/ui components, never custom styled HTML elements.
+
+Check for violations:
+- ❌ BAD: `<input className="border px-2 py-1 h-10 rounded" />`
+- ❌ BAD: `<button className="border px-3 py-1 rounded">Click</button>`
+- ✅ GOOD: `<Input />`, `<Button>Click</Button>`
+
+**Look for**: Native HTML form elements with styling classes instead of shadcn imports.
+
+### 📱 Mobile-First Responsive Design
+
+**Rule**: Always design for mobile first, then enhance for larger screens.
+
+Check for violations:
+- ❌ BAD: `lg:w-4 w-8` (desktop-first)
+- ✅ GOOD: `w-4 md:w-5` (mobile-first)
+
+**Common responsive patterns**:
+- Icons: `w-3 md:w-4` or `w-4 md:w-5`
+- Text: `text-xs md:text-sm` or `text-sm md:text-base`
+- Grids: `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`
+
+**Search for**: Reverse breakpoint order (lg before md, md before base)
+
+### 📋 Form Field Patterns
+
+Check for proper form structure:
+- Labels use `text-sm font-medium`
+- Field groups use `space-y-2` (label + input)
+- Forms use `space-y-4` (between field groups)
+- Labels have `htmlFor` matching input `id`
+- Required fields have `required` attribute
+- Inputs have appropriate placeholders
+
+**Example pattern**:
+```tsx
+<div className="space-y-2">
+  <label htmlFor="name" className="text-sm font-medium">Name</label>
+  <Input id="name" name="name" required />
+</div>
+```
+
+### 🎭 Transition & Animation Patterns
+
+Check for smooth transitions:
+- Buttons should have `transition-colors`
+- Loading spinners should have `animate-spin`
+- Inputs should have `transition-[color,box-shadow]` for focus states
+
+### 📦 Import Organization
+
+**Rule**: Imports must follow this order:
+
+1. React and Next.js
+2. Third-party libraries
+3. Actions and types (use `import type`)
+4. UI components (shadcn first, then custom)
+5. Utilities and icons (icons grouped together)
+
+**Example**:
+```tsx
+// 1. React/Next
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+// 2. Third-party
+import { DndContext } from "@dnd-kit/core";
+
+// 3. Actions/types
+import { addItem, type ActionState } from "./actions";
+
+// 4. UI components
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+
+// 5. Utilities/icons
+import { cn } from "@/lib/utils";
+import { Trash2, Loader } from "lucide-react";
+```
+
+### 🏗️ Architecture Patterns
+
+**Supabase Client Pattern** (CRITICAL):
+- ❌ NEVER create global Supabase clients
+- ✅ ALWAYS create clients inside functions
+- Server components: `const supabase = await createClient()` from `@/lib/supabase/server`
+- Client components: `const supabase = createClient()` from `@/lib/supabase/client`
+
+**Server Actions Pattern**:
+- File must start with `"use server";`
+- Export `ActionState` type: `{ ok: boolean; error?: string }`
+- Actions must call `revalidatePath()` after mutations
+- Handle PostgrestError codes (e.g., `23505` for unique violations)
+
+**File Organization**:
+- `page.tsx` - Server component for data fetching
+- `widgets.tsx` - Client components for interactive UI
+- `actions.ts` - Server actions for mutations
+
+### 🎯 Type Definitions
+
+Check for:
+- `import type` syntax for type imports
+- Explicit return types for server actions
+- Types exported from `actions.ts`
+- No `any` types (TypeScript strict mode)
+
+### 🎪 UI Pattern Compliance
+
+**Dialog Forms**:
+- Use `useActionState` with server actions
+- Define `initialState: ActionState = { ok: true }` at top
+- Close dialog with `useEffect` watching `state.ok && !pending`
+- Show loading state with `<Loader className="w-4 h-4 animate-spin" />`
+- Display errors: `{!state.ok && <p className="text-sm text-destructive">{state.error}</p>}`
+
+**Icon Constants**:
+- Define at top with `as const`
+- Example: `const ICONS = { ... } as const;`
+
+**Tooltips**:
+- Always wrap icon buttons with tooltips
+
+### 📏 Page Layout Pattern
+
+Check for consistent structure:
+```tsx
+<main className="min-h-screen flex flex-col items-center">
+  <div className="flex-1 w-full flex flex-col gap-4 items-center">
+    <PageHeader />
+    <BreadcrumbNav />
+    <section className="w-full max-w-5xl p-5 space-y-4">
+      {/* Content */}
+    </section>
+  </div>
+</main>
+```
+
+### 🔤 Naming Conventions
+
+- Files: `kebab-case.tsx`
+- Components: `PascalCase`
+- Functions: `camelCase`
+- Constants: `SCREAMING_SNAKE_CASE`
+- Types: `PascalCase`
+
+### 🎨 Text Hierarchy
+
+- Page title: `text-2xl font-semibold`
+- Section heading: `text-xl font-semibold`
+- Muted text: `text-muted-foreground`
+- Small text: `text-sm`
+- Extra small: `text-xs`
+
+### ⚠️ Error Display
+
+- Form errors: `<p className="text-sm text-destructive">{error}</p>`
+- Use `<p>` tags for form errors, not `<div>`
+- Empty states: `text-muted-foreground`
+
+## Output Format
+
+For each file reviewed, provide:
+
+### ✅ What's Good
+List patterns that are correctly implemented
+
+### ❌ Violations Found
+
+For each violation:
+1. **Severity**: Critical | Major | Minor | Suggestion
+2. **Category**: Color System | Components | Responsive | Forms | etc.
+3. **Line**: Specific line number(s)
+4. **Issue**: Description of the violation
+5. **Fix**: Concrete example of how to fix it
+
+Example:
+```
+❌ CRITICAL - Color System - Line 42
+Issue: Hardcoded color class `text-red-600` used for error message
+Fix: Replace with semantic color:
+  - text-red-600
+  + text-destructive
+```
+
+### 📊 Summary
+
+- Total violations: X
+- Critical: X | Major: X | Minor: X | Suggestions: X
+- Overall compliance: XX%
+
+### 💡 Recommendations
+
+Prioritized list of actions to take.
+
+## Additional Notes
+
+- Reference specific CLAUDE.md sections for detailed explanations
+- Focus on teaching patterns, not just pointing out errors
+- Highlight clever implementations that follow standards well
+- Consider context: some patterns may have valid exceptions

--- a/.claude/skills/review-standards/examples.md
+++ b/.claude/skills/review-standards/examples.md
@@ -1,0 +1,340 @@
+# Code Standards Examples
+
+Quick reference for common violations and fixes.
+
+## Color System Violations
+
+### ❌ Common Violations
+```tsx
+// Hardcoded red for errors
+<p className="text-red-600">{error}</p>
+
+// Hardcoded green for success
+<div className="bg-green-500">Success!</div>
+
+// Hardcoded blue for accents
+<Badge className="bg-blue-400">New</Badge>
+
+// Gray for muted text
+<span className="text-gray-500">Optional</span>
+```
+
+### ✅ Correct Usage
+```tsx
+// Semantic destructive for errors
+<p className="text-destructive">{error}</p>
+
+// Semantic tertiary for success
+<div className="bg-tertiary">Success!</div>
+
+// Semantic accent for highlights
+<Badge className="bg-accent">New</Badge>
+
+// Semantic muted for secondary text
+<span className="text-muted-foreground">Optional</span>
+```
+
+## Component Violations
+
+### ❌ Common Violations
+```tsx
+// Custom styled input
+<input
+  type="text"
+  className="border border-gray-300 px-3 py-2 rounded-md"
+/>
+
+// Custom styled button
+<button className="bg-blue-500 text-white px-4 py-2 rounded">
+  Submit
+</button>
+
+// Custom styled select
+<select className="border px-2 py-1 rounded">
+  <option>Option 1</option>
+</select>
+```
+
+### ✅ Correct Usage
+```tsx
+// shadcn Input component
+<Input type="text" />
+
+// shadcn Button component
+<Button>Submit</Button>
+
+// shadcn Select component
+<Select>
+  <SelectTrigger>
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="1">Option 1</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+## Responsive Design Violations
+
+### ❌ Common Violations (Desktop-First)
+```tsx
+// Large icons shrinking on mobile
+<Icon className="w-6 md:w-4" />
+
+// Text getting smaller on mobile
+<p className="text-base md:text-sm">Content</p>
+
+// Grid collapsing to single column on mobile
+<div className="grid-cols-3 md:grid-cols-1">
+```
+
+### ✅ Correct Usage (Mobile-First)
+```tsx
+// Small icons growing on desktop
+<Icon className="w-4 md:w-6" />
+
+// Small text growing on desktop
+<p className="text-sm md:text-base">Content</p>
+
+// Single column expanding to grid on larger screens
+<div className="grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+```
+
+## Import Organization Violations
+
+### ❌ Common Violations
+```tsx
+// Unorganized imports
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { ActionState } from "./actions";
+import { cn } from "@/lib/utils";
+```
+
+### ✅ Correct Usage
+```tsx
+// Properly organized imports
+// 1. React/Next
+import { useState } from "react";
+
+// 2. Third-party
+// (none in this example)
+
+// 3. Actions/types
+import type { ActionState } from "./actions";
+
+// 4. UI components
+import { Button } from "@/components/ui/button";
+
+// 5. Utilities/icons
+import { createClient } from "@/lib/supabase/client";
+import { cn } from "@/lib/utils";
+import { Trash2 } from "lucide-react";
+```
+
+## Supabase Client Violations
+
+### ❌ CRITICAL Violation
+```tsx
+// Global Supabase client (breaks Fluid compute)
+const supabase = createClient();
+
+export default function Page() {
+  const { data } = await supabase.from("table").select("*");
+  // ...
+}
+```
+
+### ✅ Correct Usage
+```tsx
+// Client created inside function
+export default async function Page() {
+  const supabase = await createClient();
+  const { data } = await supabase.from("table").select("*");
+  // ...
+}
+```
+
+## Form Pattern Violations
+
+### ❌ Common Violations
+```tsx
+// Missing label, no spacing, inline styles
+<div>
+  <input
+    name="email"
+    className="border px-2 py-1"
+    placeholder="Email"
+  />
+</div>
+
+// Label without htmlFor
+<label>Name</label>
+<Input name="name" />
+```
+
+### ✅ Correct Usage
+```tsx
+// Proper spacing, semantic label, htmlFor connection
+<div className="space-y-2">
+  <label htmlFor="email" className="text-sm font-medium">
+    Email
+  </label>
+  <Input
+    id="email"
+    name="email"
+    type="email"
+    required
+    placeholder="you@example.com"
+  />
+</div>
+```
+
+## Server Action Violations
+
+### ❌ Common Violations
+```tsx
+// Missing "use server"
+import { createClient } from "@/lib/supabase/server";
+
+export async function addItem(formData: FormData) {
+  // ...
+}
+
+// No error handling
+export async function addItem(formData: FormData) {
+  "use server";
+  const supabase = await createClient();
+  await supabase.from("items").insert({ name: formData.get("name") });
+  // Missing revalidatePath, no error handling
+}
+```
+
+### ✅ Correct Usage
+```tsx
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export type ActionState = {
+  ok: boolean;
+  error?: string;
+};
+
+export async function addItem(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const supabase = await createClient();
+
+  const name = String(formData.get("name") || "").trim();
+  if (!name) {
+    return { ok: false, error: "Name is required" };
+  }
+
+  const { error } = await supabase.from("items").insert({ name });
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  revalidatePath("/path");
+  return { ok: true };
+}
+```
+
+## Dialog Form Violations
+
+### ❌ Common Violations
+```tsx
+// No loading state, manual form handling, no error display
+function AddDialog() {
+  const [open, setOpen] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    // Manual form handling...
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <form onSubmit={handleSubmit}>
+        <Input name="name" />
+        <Button type="submit">Save</Button>
+      </form>
+    </Dialog>
+  );
+}
+```
+
+### ✅ Correct Usage
+```tsx
+import { useActionState, useEffect } from "react";
+import { addItem, type ActionState } from "./actions";
+
+const initialState: ActionState = { ok: true };
+
+function AddDialog() {
+  const [open, setOpen] = useState(false);
+  const [state, formAction, pending] = useActionState(addItem, initialState);
+
+  // Close on success
+  useEffect(() => {
+    if (state.ok && !pending) {
+      setOpen(false);
+    }
+  }, [state.ok, pending]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <form action={formAction} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="name" className="text-sm font-medium">Name</label>
+            <Input id="name" name="name" required />
+          </div>
+
+          {!state.ok && (
+            <p className="text-sm text-destructive">{state.error}</p>
+          )}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button type="submit" disabled={pending}>
+              {pending ? <Loader className="w-4 h-4 animate-spin" /> : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+## Transition Violations
+
+### ❌ Missing Transitions
+```tsx
+// Button with no transition
+<Button className="hover:bg-primary/90">Click</Button>
+
+// Input with no focus transition
+<Input className="focus:ring-2" />
+```
+
+### ✅ With Transitions
+```tsx
+// Button with smooth color transition
+<Button className="transition-colors hover:bg-primary/90">Click</Button>
+
+// Input with smooth focus transition
+<Input className="transition-[color,box-shadow] focus-visible:ring-ring/50" />
+
+// Loading spinner
+<Loader className="w-4 h-4 animate-spin" />
+```


### PR DESCRIPTION
## Summary
- Commits `.claude/skills/review-standards/` (`SKILL.md` + `examples.md`), a custom skill that reviews code against this repo's CLAUDE.md conventions (color system, component usage, responsive design, form patterns, imports, types).
- This was previously untracked local tooling, only visible now that `.claude/` was un-gitignored in #31. Separated into its own PR since it's unrelated to the agent-loop/CI work.

## Notes
- `components/ui/select.tsx` (a shadcn Select component, unrelated in-progress work) is intentionally left untracked/uncommitted — not part of this PR's scope.